### PR TITLE
Using JSON to serialize log messages.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vendor/qt-json"]
+	path = vendor/qt-json
+	url = git://github.com/ereilin/qt-json.git

--- a/build/greenj.pro
+++ b/build/greenj.pro
@@ -31,6 +31,7 @@ mac {
 	PJSIP_TARGET = i386-apple-darwin11.3.0
 }
 SOURCEDIR = ../src
+VENDORDIR = ../vendor
 RESOURCEDIR = ../res
 
 #CONFIG += debug
@@ -42,6 +43,7 @@ DEFINES += DEBUG
 INCLUDEPATH += $$SOURCEDIR/GeneratedFiles \
     $$SOURCEDIR/GeneratedFiles/Debug \
     $$SOURCEDIR \
+    $$VENDORDIR/qt-json \
     $$PJSIP_DIR \
 	$$PJSIP_DIR/pjmedia/include \
     $$PJSIP_DIR/pjsip/include \
@@ -150,7 +152,8 @@ SOURCES += $$SOURCEDIR/main.cpp \
     $$SOURCEDIR/JavascriptHandler.cpp \
     $$SOURCEDIR/LogHandler.cpp \
     $$SOURCEDIR/PrintHandler.cpp \
-    $$SOURCEDIR/Sound.cpp
+    $$SOURCEDIR/Sound.cpp \
+    $$VENDORDIR/qt-json/json.cpp
 FORMS += $$SOURCEDIR/gui.ui
 RESOURCES += $$RESOURCEDIR/gui.qrc
 

--- a/src/JavascriptHandler.cpp
+++ b/src/JavascriptHandler.cpp
@@ -17,10 +17,12 @@
 #include "LogHandler.h"
 #include "Config.h"
 #include "JavascriptHandler.h"
+#include "json.h"
 
 using phone::Phone;
 using phone::Call;
 using phone::Account;
+using QtJson::Json;
 
 const QString JavascriptHandler::OBJECT_NAME = "qt_handler";
 
@@ -440,11 +442,11 @@ void JavascriptHandler::deleteLogFile(const QString &file_name) const
 //-----------------------------------------------------------------------------
 void JavascriptHandler::slotLogMessage(const LogInfo &info) const
 {
-    QString json = "{'time':'" + info.time_.toString("dd.MM.yyyy hh:mm:ss")
-                 + "','status':" + QString::number(info.status_) 
-                 + ",'domain':'" + info.domain_
-                 + "','code':" + QString::number(info.code_) 
-                 + ",'message':'" + info.msg_ + "'}";
-
-    evaluateJavaScript("logMessage(" + json + ")");
+    QVariantMap map;
+    map["time"] = info.time_.toString("dd.MM.yyyy hh:mm:ss");
+    map["status"] = QString::number(info.status_);
+    map["domain"] = info.domain_;
+    map["code"] = QString::number(info.code_);
+    map["message"] = info.msg_;
+    evaluateJavaScript("logMessage(" + Json::serialize(map) + ")");
 }


### PR DESCRIPTION
Many log messages trigger an error because they contain characters such as `'`. This patch uses qt-json to fix the problem.
